### PR TITLE
[ARV-162] Access Token Cookie에 저장 및 검증되도록 수정

### DIFF
--- a/src/main/java/com/backend/allreva/auth/application/AuthService.java
+++ b/src/main/java/com/backend/allreva/auth/application/AuthService.java
@@ -42,7 +42,6 @@ public class AuthService {
             return getMemberInfo(memberOptional.get());
         }
         return getTemporaryMemberInfo(userInfo);
-
     }
 
     private LoginResponse getTemporaryMemberInfo(final UserInfo userInfo) {

--- a/src/main/java/com/backend/allreva/auth/application/CookieService.java
+++ b/src/main/java/com/backend/allreva/auth/application/CookieService.java
@@ -25,4 +25,17 @@ public class CookieService {
                 refreshTime
         );
     }
+
+    public void addAccessTokenCookie(
+            final HttpServletResponse response,
+            final String accessToken
+    ) {
+        CookieUtils.addCookie(
+                response,
+                domainName,
+                "accessToken",
+                accessToken,
+                refreshTime
+        );
+    }
 }

--- a/src/main/java/com/backend/allreva/auth/application/JwtService.java
+++ b/src/main/java/com/backend/allreva/auth/application/JwtService.java
@@ -11,13 +11,11 @@ import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.Date;
 import javax.crypto.SecretKey;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
 @Slf4j
 @Service
@@ -39,20 +37,6 @@ public class JwtService {
         this.accessTime = accessTime;
         this.refreshTime = refreshTime;
         this.refreshTokenRepository = refreshTokenRepository;
-    }
-
-    /**
-     * header에 있는 Access Token을 추출합니다.
-     * @param request HTTP 요청
-     * @return Access Token String 값
-     */
-    public String extractAccessToken(final HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
-        }
-        return null;
     }
 
     /**

--- a/src/main/java/com/backend/allreva/auth/ui/AuthController.java
+++ b/src/main/java/com/backend/allreva/auth/ui/AuthController.java
@@ -31,7 +31,7 @@ public class AuthController implements AuthControllerSwagger {
         LoginResponse loginResponse = authService.kakaoLogin(authorizationCode);
         if (loginResponse.isUser()) {
             cookieService.addRefreshTokenCookie(response, loginResponse.refreshToken());
-            response.addHeader("Authorization", "Bearer " + loginResponse.accessToken());
+            cookieService.addAccessTokenCookie(response, loginResponse.accessToken());
         }
         return Response.onSuccess(loginResponse);
     }
@@ -43,7 +43,7 @@ public class AuthController implements AuthControllerSwagger {
     ) {
         ReissueResponse reissueResponse = authService.reissueAccessToken(reissueRequest);
         cookieService.addRefreshTokenCookie(response, reissueResponse.refreshToken());
-        response.addHeader("Authorization", "Bearer " + reissueResponse.accessToken());
+        cookieService.addAccessTokenCookie(response, reissueResponse.accessToken());
         return Response.onSuccess(reissueResponse);
     }
 }

--- a/src/main/java/com/backend/allreva/common/util/CookieUtils.java
+++ b/src/main/java/com/backend/allreva/common/util/CookieUtils.java
@@ -18,7 +18,7 @@ public final class CookieUtils {
             final int maxAge
     ) {
         ResponseCookie cookie = ResponseCookie.from(name, value)
-                //.domain(cookieDomain)
+                .domain(isLocalhost(cookieDomain) ? null : cookieDomain)
                 .path("/")
                 .maxAge(maxAge)
                 .httpOnly(true)
@@ -27,5 +27,9 @@ public final class CookieUtils {
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    private static boolean isLocalhost(String domain) {
+        return domain.equals("localhost");
     }
 }


### PR DESCRIPTION
### 연결된 issue 🌟
- closed #135 

### 구현 내용 📢
#### access token Header 대신 Cookie에 저장 및 인증하도록 수정

- Cookie에 공백을 저장할 수 없는 관계로 편의 상 "Bearer "접두어를 제거하였습니다.
- Cookie 안에 "accessToken"의 value 값으로 어떤 값이든 있기만 한다면 인증 절차가 작동합니다.

#### Cookie Domain을 yml로 변경할 수 있도록 수정

기존에 Cookie의 `domain()`값을 아예 없애거나 `null`값으로 설정해야 localhost 테스트를 통과합니다.

이는 브라우저마다 정책이 약간 다를 수 있지만, 크롬 기준으로 Cookie에 domain을 설정하지 않을 경우 localhost에서 볼 수 있도록 설정되어 있습니다. 만일 `domain("localhost")`라고 한다면 크롬은 정책 상 막아놓습니다. 아예 null값이나 설정을 안해야 됩니다!