### PR TITLE
[ARV-144] 검색어 증가 구현

### DIFF
--- a/src/main/java/com/backend/allreva/concert/query/application/ConcertSearchService.java
+++ b/src/main/java/com/backend/allreva/concert/query/application/ConcertSearchService.java
@@ -7,6 +7,7 @@ import com.backend.allreva.concert.exception.search.ElasticSearchException;
 import com.backend.allreva.concert.exception.search.SearchResultNotFoundException;
 import com.backend.allreva.concert.query.application.response.ConcertSearchListResponse;
 import com.backend.allreva.concert.infra.elasticsearch.ConcertDocument;
+import com.backend.allreva.keyword.command.PopularKeywordCommandService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.elasticsearch.core.SearchHit;
@@ -21,14 +22,18 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class ConcertSearchService {
     private final ConcertSearchRepository concertSearchRepository;
+    private final PopularKeywordCommandService popularKeywordCommandService;
 
     public List<ConcertThumbnail> searchConcertThumbnails(final String title) {
         try {
+            popularKeywordCommandService.updateKeywordCount(title);
+
             List<ConcertDocument> content = concertSearchRepository.findByTitleMixed(
                     title, PageRequest.of(0, 2)).getContent();
             if (content.isEmpty()) {
                 throw new SearchResultNotFoundException();
             }
+
             return content.stream()
                     .map(ConcertThumbnail::from)
                     .toList();


### PR DESCRIPTION
### 연결된 issue 🌟
<br>
- closed #126

### 구현 내용 📢
검색 시에 어차피 콘서트 검색, 차대절 검색, 수요조사 검색 api가 모두 호출되기 때문에, 검색어는 1번만 증가시키기 위해 콘서트 검색에만 증가 로직을 부여하였습니다.

