### PR TITLE
[ARV-175] 차량 대절 사진 저장 로직 및 날짜, 참석자 수 데이터 조회 이슈 수정

### DIFF
--- a/src/main/java/com/backend/allreva/rent/command/application/RentCommandFacade.java
+++ b/src/main/java/com/backend/allreva/rent/command/application/RentCommandFacade.java
@@ -1,0 +1,52 @@
+package com.backend.allreva.rent.command.application;
+
+import com.backend.allreva.common.application.S3ImageService;
+import com.backend.allreva.common.model.Image;
+import com.backend.allreva.rent.command.application.request.RentIdRequest;
+import com.backend.allreva.rent.command.application.request.RentRegisterRequest;
+import com.backend.allreva.rent.command.application.request.RentUpdateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RentCommandFacade {
+
+    private final RentCommandService rentCommandService;
+    private final S3ImageService s3ImageService;
+
+    public Long registerRent(
+            final RentRegisterRequest rentRegisterRequest,
+            final MultipartFile image,
+            final Long memberId
+    ) {
+        Image uploadedImage = s3ImageService.upload(image);
+        return rentCommandService.registerRent(rentRegisterRequest, uploadedImage, memberId);
+    }
+
+    public void updateRent(
+            final RentUpdateRequest rentUpdateRequest,
+            final MultipartFile image,
+            final Long memberId
+    ) {
+        Image uploadedImage = s3ImageService.upload(image);
+        rentCommandService.updateRent(rentUpdateRequest, uploadedImage, memberId);
+    }
+
+    public void closeRent(
+            final RentIdRequest rentIdRequest,
+            final Long memberId
+    ) {
+        rentCommandService.closeRent(rentIdRequest, memberId);
+    }
+
+    public void deleteRent(
+            final RentIdRequest rentIdRequest,
+            final Long memberId
+    ) {
+        rentCommandService.deleteRent(rentIdRequest, memberId);
+    }
+}

--- a/src/main/java/com/backend/allreva/rent/command/application/RentCommandService.java
+++ b/src/main/java/com/backend/allreva/rent/command/application/RentCommandService.java
@@ -1,14 +1,16 @@
 package com.backend.allreva.rent.command.application;
 
 import com.backend.allreva.common.event.Events;
+import com.backend.allreva.common.model.Image;
 import com.backend.allreva.rent.command.application.request.RentIdRequest;
 import com.backend.allreva.rent.command.application.request.RentRegisterRequest;
 import com.backend.allreva.rent.command.application.request.RentUpdateRequest;
-import com.backend.allreva.rent.command.domain.*;
+import com.backend.allreva.rent.command.domain.Rent;
+import com.backend.allreva.rent.command.domain.RentRepository;
+import com.backend.allreva.rent.command.domain.RentSaveEvent;
 import com.backend.allreva.rent.exception.RentNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -20,9 +22,10 @@ public class RentCommandService {
 
     public Long registerRent(
             final RentRegisterRequest rentRegisterRequest,
+            final Image image,
             final Long memberId
     ) {
-        Rent rent = rentRegisterRequest.toEntity(memberId);
+        Rent rent = rentRegisterRequest.toEntity(memberId, image);
         Rent savedRent = rentRepository.save(rent);
         Events.raise(new RentSaveEvent(savedRent));
         return savedRent.getId();
@@ -30,6 +33,7 @@ public class RentCommandService {
 
     public void updateRent(
             final RentUpdateRequest rentUpdateRequest,
+            final Image image,
             final Long memberId
     ) {
         Rent rent = rentRepository.findById(rentUpdateRequest.rentId())
@@ -38,7 +42,7 @@ public class RentCommandService {
         rent.validateMine(memberId);
 
         rentRepository.deleteBoardingDateAllByRentId(rentUpdateRequest.rentId());
-        rent.updateRent(rentUpdateRequest);
+        rent.updateRent(rentUpdateRequest, image);
     }
 
     public void closeRent(

--- a/src/main/java/com/backend/allreva/rent/command/application/request/RentRegisterRequest.java
+++ b/src/main/java/com/backend/allreva/rent/command/application/request/RentRegisterRequest.java
@@ -27,7 +27,6 @@ public record RentRegisterRequest(
         Long concertId,
         @NotBlank
         String title,
-        String imageUrl,
         @NotNull
         String artistName,
         @NotNull
@@ -65,7 +64,10 @@ public record RentRegisterRequest(
         String information
 ) {
 
-    public Rent toEntity(final Long memberId) {
+    public Rent toEntity(
+            final Long memberId,
+            final Image image
+    ) {
         Rent rent = Rent.builder()
                 .memberId(memberId)
                 .concertId(concertId)
@@ -75,7 +77,7 @@ public record RentRegisterRequest(
                                 .build())
                         .toList())
                 .detailInfo(DetailInfo.builder()
-                        .image(new Image(imageUrl))
+                        .image(image)
                         .title(title)
                         .artistName(artistName)
                         .depositAccount(depositAccount)

--- a/src/main/java/com/backend/allreva/rent/command/application/request/RentUpdateRequest.java
+++ b/src/main/java/com/backend/allreva/rent/command/application/request/RentUpdateRequest.java
@@ -16,7 +16,6 @@ import java.util.List;
 public record RentUpdateRequest(
         @NotNull
         Long rentId,
-        String imageUrl,
         @NotNull
         Region region, // enum 파싱
         @NotNull

--- a/src/main/java/com/backend/allreva/rent/command/domain/Rent.java
+++ b/src/main/java/com/backend/allreva/rent/command/domain/Rent.java
@@ -55,11 +55,14 @@ public class Rent extends BaseEntity {
         this.boardingDates = boardingDates;
     }
 
-    public void updateRent(RentUpdateRequest request) {
+    public void updateRent(
+            final RentUpdateRequest request,
+            final Image image
+    ) {
         this.detailInfo = DetailInfo.builder()
                 .title(detailInfo.getTitle())
                 .artistName(detailInfo.getArtistName())
-                .image(new Image(request.imageUrl()))
+                .image(image)
                 .region(request.region())
                 .depositAccount(detailInfo.getDepositAccount())
                 .build();

--- a/src/main/java/com/backend/allreva/rent/query/application/response/RentDetailResponse.java
+++ b/src/main/java/com/backend/allreva/rent/query/application/response/RentDetailResponse.java
@@ -2,35 +2,85 @@ package com.backend.allreva.rent.query.application.response;
 
 import com.backend.allreva.rent.command.domain.value.BusSize;
 import com.backend.allreva.rent.command.domain.value.BusType;
-import com.backend.allreva.rent_join.command.domain.value.RefundType;
 import com.backend.allreva.rent.command.domain.value.Region;
+import com.backend.allreva.rent_join.command.domain.value.RefundType;
 import java.time.LocalDate;
 import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 
-public record RentDetailResponse(
-        String concertName, // 콘서트 이름
-        String imageUrl, // 콘서트 이미지
-        String title, // 차량 대절 이름
-        String artistName, // 아티스트 이름
-        Region region, // 차량 대절 지역
-        String boardingArea, // 상행 지역
-        String dropOffArea, // 하행 지역 -> concerthall code 조인
-        String upTime, // 상행 시간
-        String downTime, // 하행 시간
-        List<RentBoardingDateResponse> boardingDates,
-        BusSize busSize, // 차량 정보 - 사이즈
-        BusType busType, // 차량 정보 - 버스 타입
-        int maxPassenger, // 차량 정보 - 최대 탑승 인원
-        int roundPrice, // 왕복 가격
-        int upTimePrice, // 상행 가격
-        int downTimePrice, // 하행 가격
-        int recruitmentCount, // 모집 인원
-        LocalDate endDate, // 마감일
-        String chatUrl, // 채팅 url - 지금은 필요없을듯 일단은 넣어놓자.
-        RefundType refundType, //
-        String information, // 기타 안내 사항
-        boolean isClosed // 마감 여부
-) {
+@Getter
+public class RentDetailResponse {
+
+    private final String concertName; // 콘서트 이름
+    private final String imageUrl; // 콘서트 이미지
+    private final String title; // 차량 대절 이름
+    private final String artistName; // 아티스트 이름
+    private final Region region; // 차량 대절 지역
+    private final String boardingArea; // 상행 지역
+    private final String dropOffArea; // 하행 지역 -> concerthall code 조인
+    private final String upTime; // 상행 시간
+    private final String downTime; // 하행 시간
+    @Setter
+    private List<RentBoardingDateResponse> boardingDates;
+    private final BusSize busSize; // 차량 정보 - 사이즈
+    private final BusType busType; // 차량 정보 - 버스 타입
+    private final int maxPassenger; // 차량 정보 - 최대 탑승 인원
+    private final int roundPrice; // 왕복 가격
+    private final int upTimePrice; // 상행 가격
+    private final int downTimePrice; // 하행 가격
+    private final int recruitmentCount; // 모집 인원
+    private final LocalDate endDate; // 마감일
+    private final String chatUrl; // 채팅 url - 지금은 필요없을듯 일단은 넣어놓자.
+    private final RefundType refundType; //
+    private final String information; // 기타 안내 사항
+    private final boolean isClosed; // 마감 여부
+
+    public RentDetailResponse(
+            String concertName,
+            String imageUrl,
+            String title,
+            String artistName,
+            Region region,
+            String boardingArea,
+            String dropOffArea,
+            String upTime,
+            String downTime,
+            BusSize busSize,
+            BusType busType,
+            int maxPassenger,
+            int roundPrice,
+            int upTimePrice,
+            int downTimePrice,
+            int recruitmentCount,
+            LocalDate endDate,
+            String chatUrl,
+            RefundType refundType,
+            String information,
+            boolean isClosed
+    ) {
+        this.concertName = concertName;
+        this.imageUrl = imageUrl;
+        this.title = title;
+        this.artistName = artistName;
+        this.region = region;
+        this.boardingArea = boardingArea;
+        this.dropOffArea = dropOffArea;
+        this.upTime = upTime;
+        this.downTime = downTime;
+        this.busSize = busSize;
+        this.busType = busType;
+        this.maxPassenger = maxPassenger;
+        this.roundPrice = roundPrice;
+        this.upTimePrice = upTimePrice;
+        this.downTimePrice = downTimePrice;
+        this.recruitmentCount = recruitmentCount;
+        this.endDate = endDate;
+        this.chatUrl = chatUrl;
+        this.refundType = refundType;
+        this.information = information;
+        this.isClosed = isClosed;
+    }
 
     public record RentBoardingDateResponse(
             LocalDate date,

--- a/src/main/java/com/backend/allreva/rent/ui/RentController.java
+++ b/src/main/java/com/backend/allreva/rent/ui/RentController.java
@@ -3,7 +3,7 @@ package com.backend.allreva.rent.ui;
 import com.backend.allreva.auth.security.AuthMember;
 import com.backend.allreva.common.dto.Response;
 import com.backend.allreva.member.command.domain.Member;
-import com.backend.allreva.rent.command.application.RentCommandService;
+import com.backend.allreva.rent.command.application.RentCommandFacade;
 import com.backend.allreva.rent.command.application.request.RentIdRequest;
 import com.backend.allreva.rent.command.application.request.RentRegisterRequest;
 import com.backend.allreva.rent.command.application.request.RentUpdateRequest;
@@ -19,6 +19,7 @@ import jakarta.validation.constraints.Min;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,7 +29,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Validated
 @RestController
@@ -36,25 +39,26 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/rents")
 public class RentController implements RentControllerSwagger {
 
-    private final RentCommandService rentCommandService;
+    private final RentCommandFacade rentCommandFacade;
     private final RentQueryService rentQueryService;
 
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public Response<Long> createRent(
-            @RequestBody final RentRegisterRequest rentRegisterRequest,
+            @RequestPart final RentRegisterRequest rentRegisterRequest,
+            @RequestPart(value = "image", required = false) final MultipartFile image,
             @AuthMember final Member member
     ) {
-        Long rentIdResponse = rentCommandService.registerRent(rentRegisterRequest, member.getId());
-
+        Long rentIdResponse = rentCommandFacade.registerRent(rentRegisterRequest, image, member.getId());
         return Response.onSuccess(rentIdResponse);
     }
 
-    @PatchMapping
+    @PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public Response<Void> updateRent(
-            @RequestBody final RentUpdateRequest rentUpdateRequest,
+            @RequestPart final RentUpdateRequest rentUpdateRequest,
+            @RequestPart(value = "image", required = false) final MultipartFile image,
             @AuthMember final Member member
     ) {
-        rentCommandService.updateRent(rentUpdateRequest, member.getId());
+        rentCommandFacade.updateRent(rentUpdateRequest, image, member.getId());
         return Response.onSuccess();
     }
 
@@ -63,7 +67,7 @@ public class RentController implements RentControllerSwagger {
             @RequestBody final RentIdRequest rentIdRequest,
             @AuthMember final Member member
     ) {
-        rentCommandService.closeRent(rentIdRequest, member.getId());
+        rentCommandFacade.closeRent(rentIdRequest, member.getId());
         return Response.onSuccess();
     }
 
@@ -72,7 +76,7 @@ public class RentController implements RentControllerSwagger {
             @RequestBody final RentIdRequest rentIdRequest,
             @AuthMember final Member member
     ) {
-        rentCommandService.deleteRent(rentIdRequest, member.getId());
+        rentCommandFacade.deleteRent(rentIdRequest, member.getId());
         return Response.onSuccess();
     }
 

--- a/src/main/java/com/backend/allreva/rent/ui/RentControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/rent/ui/RentControllerSwagger.java
@@ -1,6 +1,5 @@
 package com.backend.allreva.rent.ui;
 
-import com.backend.allreva.auth.security.AuthMember;
 import com.backend.allreva.common.dto.Response;
 import com.backend.allreva.member.command.domain.Member;
 import com.backend.allreva.rent.command.application.request.RentIdRequest;
@@ -14,37 +13,51 @@ import com.backend.allreva.rent.query.application.response.RentDetailResponse;
 import com.backend.allreva.rent.query.application.response.RentSummaryResponse;
 import com.backend.allreva.survey.query.application.response.SortType;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
 import java.time.LocalDate;
 import java.util.List;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.http.MediaType;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "차량 대절 폼 API")
 public interface RentControllerSwagger {
 
     @Operation(summary = "차량 대절 생성 API", description = "차량 대절 폼을 생성합니다.")
+    @RequestBody(
+            content = @Content(
+                    encoding = @Encoding(
+                            name = "rentRegisterRequest", contentType = MediaType.APPLICATION_JSON_VALUE)))
     Response<Long> createRent(
-            @RequestBody RentRegisterRequest rentRegisterRequest,
-            @AuthMember Member member
+            RentRegisterRequest rentRegisterRequest,
+            MultipartFile image,
+            Member member
     );
 
     @Operation(summary = "차량 대절 수정 API", description = "차량 대절 폼을 수정합니다.")
+    @RequestBody(
+            content = @Content(
+                    encoding = @Encoding(
+                            name = "rentUpdateRequest", contentType = MediaType.APPLICATION_JSON_VALUE)))
     Response<Void> updateRent(
-            @RequestBody RentUpdateRequest rentUpdateRequest,
-            @AuthMember Member member
+            RentUpdateRequest rentUpdateRequest,
+            MultipartFile image,
+            Member member
     );
 
     @Operation(summary = "차량 대절 마감 API", description = "차량 대절 폼을 마감합니다.")
     Response<Void> closeRent(
-            @RequestBody RentIdRequest rentIdRequest,
-            @AuthMember Member member
+            RentIdRequest rentIdRequest,
+            Member member
     );
 
     @Operation(summary = "차량 대절 삭제 API", description = "차량 대절 폼을 삭제합니다.")
     Response<Void> deleteRent(
-            @RequestBody final RentIdRequest rentIdRequest,
-            @AuthMember final Member member
+            RentIdRequest rentIdRequest,
+            Member member
     );
 
     @Operation(

--- a/src/test/java/com/backend/allreva/rent/fixture/RentRegisterRequestFixture.java
+++ b/src/test/java/com/backend/allreva/rent/fixture/RentRegisterRequestFixture.java
@@ -16,7 +16,6 @@ public final class RentRegisterRequestFixture {
     public static RentRegisterRequest createRentRegisterRequestFixture() {
         return new RentRegisterRequest(
                 1L,
-                "imageUrl",
                 "title",
                 "artistName",
                 Region.서울,

--- a/src/test/java/com/backend/allreva/rent/fixture/RentUpdateRequestFixture.java
+++ b/src/test/java/com/backend/allreva/rent/fixture/RentUpdateRequestFixture.java
@@ -16,7 +16,6 @@ public final class RentUpdateRequestFixture {
     public static RentUpdateRequest createRentUpdateRequestFixture(final Long rentId) {
         return new RentUpdateRequest(
                 rentId,
-                "imageUrl",
                 Region.서울,
                 "영주",
                 "09:00",

--- a/src/test/java/com/backend/allreva/rent/integration/RentMainPageTest.java
+++ b/src/test/java/com/backend/allreva/rent/integration/RentMainPageTest.java
@@ -104,10 +104,10 @@ class RentMainPageTest extends IntegrationTestSupport {
         // then
         assertThat(rentDetail).isNotNull();
         assertSoftly(softly -> {
-            softly.assertThat(rentDetail.title()).isEqualTo(savedRent.getDetailInfo().getTitle());
-            softly.assertThat(rentDetail.concertName()).isEqualTo(concert.getConcertInfo().getTitle());
-            softly.assertThat(rentDetail.dropOffArea()).isEqualTo(concertHall.getName());
-            softly.assertThat(rentDetail.boardingDates().get(0).participationCount()).isEqualTo(2);
+            softly.assertThat(rentDetail.getTitle()).isEqualTo(savedRent.getDetailInfo().getTitle());
+            softly.assertThat(rentDetail.getConcertName()).isEqualTo(concert.getConcertInfo().getTitle());
+            softly.assertThat(rentDetail.getDropOffArea()).isEqualTo(concertHall.getName());
+            softly.assertThat(rentDetail.getBoardingDates().get(0).participationCount()).isEqualTo(2);
         });
     }
 

--- a/src/test/java/com/backend/allreva/rent/integration/RentRegisterTest.java
+++ b/src/test/java/com/backend/allreva/rent/integration/RentRegisterTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import com.backend.allreva.common.model.Image;
 import com.backend.allreva.rent.command.application.RentCommandService;
 import com.backend.allreva.rent.command.domain.Rent;
 import com.backend.allreva.rent.command.domain.RentRepository;
@@ -32,10 +33,11 @@ class RentRegisterTest {
         // given
         var memberId = 1L;
         var rentFormRequest = createRentRegisterRequestFixture();
+        var uploadedImage = new Image("test url");
         given(rentRepository.save(any(Rent.class))).willAnswer(invocation -> invocation.getArgument(0));
 
         // when
-        rentCommandService.registerRent(rentFormRequest, memberId);
+        rentCommandService.registerRent(rentFormRequest, uploadedImage, memberId);
 
         // then
         var capturedRent = getArgumentCaptorValue();

--- a/src/test/java/com/backend/allreva/rent/integration/RentUpdateTest.java
+++ b/src/test/java/com/backend/allreva/rent/integration/RentUpdateTest.java
@@ -9,6 +9,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.backend.allreva.common.model.Image;
 import com.backend.allreva.rent.command.application.RentCommandService;
 import com.backend.allreva.rent.command.domain.RentRepository;
 import com.backend.allreva.rent.exception.RentAccessDeniedException;
@@ -36,10 +37,11 @@ class RentUpdateTest {
         var memberId = 1L;
         var rentRequest = createRentUpdateRequestFixture(1L);
         var rent = createRentFixture(memberId, 1L);
+        var uploadedImage = new Image("test url");
         given(rentRepository.findById(anyLong())).willReturn(Optional.of(rent));
 
         // when
-        rentCommandService.updateRent(rentRequest, memberId);
+        rentCommandService.updateRent(rentRequest, uploadedImage, memberId);
 
         // then
         assertSoftly(softly -> {
@@ -53,11 +55,12 @@ class RentUpdateTest {
         // given
         var anotherMemberId = 2L;
         var rentUpdateRequest = createRentUpdateRequestFixture(1L);
+        var uploadedImage = new Image("test url");
         given(rentRepository.findById(anyLong())).willReturn(Optional.of(createRentFixture(1L, 1L)));
 
         // when & then
         assertThrows(RentAccessDeniedException.class,
-                () -> rentCommandService.updateRent(rentUpdateRequest, anotherMemberId));
+                () -> rentCommandService.updateRent(rentUpdateRequest, uploadedImage, anotherMemberId));
         verify(rentRepository, times(1)).findById(anyLong());
     }
 
@@ -67,10 +70,11 @@ class RentUpdateTest {
         // given
         var memberId = 1L;
         var rentUpdateRequest = createRentUpdateRequestFixture(1L);
+        var uploadedImage = new Image("test url");
         given(rentRepository.findById(anyLong())).willReturn(Optional.empty());
 
         // when & then
         assertThrows(RentNotFoundException.class,
-                () -> rentCommandService.updateRent(rentUpdateRequest, memberId));
+                () -> rentCommandService.updateRent(rentUpdateRequest, uploadedImage, memberId));
     }
 }


### PR DESCRIPTION
### 연결된 issue 🌟
- closed #153

### 구현 내용 📢
#### 차량 대절 사진 저장 로직 구현
기존에 차량 대절 추가 및 수정 작업에서 임시로 imageUrl을 바로 받았는데, 이를 multipart form data로 받아와서 S3에 저장할 수 있도록 수정했습니다.

#### rentboardingDates 조회 쿼리 수정
기존 차량 대절 상세 조회에서 rentBoardingDates 데이터가 1개 밖에 나오지 않는 이슈가 발생하여,
기존에 Projections 안에 list로 한번 더 Projections 했던 것을, 쿼리를 아예 분리하여 DTO에 추가적으로 Set 하도록 변경했습니다.

### 앞으로 해야할 것
- s3 transactional 고려 or 비동기 구현
- 쿼리 시간 측정
