### PR TITLE
차량 대절 상세 조회 시 날짜 별 신청 여부 및 환불 계좌 조회 기능 추가

### DIFF
--- a/src/main/java/com/backend/allreva/rent/query/application/RentQueryService.java
+++ b/src/main/java/com/backend/allreva/rent/query/application/RentQueryService.java
@@ -23,7 +23,6 @@ public class RentQueryService {
 
     private final RentRepository rentRepository;
     private final RentJoinRepository rentJoinRepository;
-    private final MemberRepository memberRepository;
 
     public List<RentSummaryResponse> getRentSummaries(
             final Region region,

--- a/src/main/java/com/backend/allreva/rent/query/application/RentQueryService.java
+++ b/src/main/java/com/backend/allreva/rent/query/application/RentQueryService.java
@@ -1,5 +1,7 @@
 package com.backend.allreva.rent.query.application;
 
+import com.backend.allreva.member.command.domain.Member;
+import com.backend.allreva.member.command.domain.MemberRepository;
 import com.backend.allreva.rent.command.domain.RentRepository;
 import com.backend.allreva.rent.command.domain.value.Region;
 import com.backend.allreva.rent.exception.RentNotFoundException;
@@ -8,6 +10,7 @@ import com.backend.allreva.rent.query.application.response.RentAdminDetailRespon
 import com.backend.allreva.rent.query.application.response.RentAdminSummaryResponse;
 import com.backend.allreva.rent.query.application.response.RentDetailResponse;
 import com.backend.allreva.rent.query.application.response.RentSummaryResponse;
+import com.backend.allreva.rent_join.command.domain.RentJoinRepository;
 import com.backend.allreva.survey.query.application.response.SortType;
 import java.time.LocalDate;
 import java.util.List;
@@ -19,6 +22,8 @@ import org.springframework.stereotype.Service;
 public class RentQueryService {
 
     private final RentRepository rentRepository;
+    private final RentJoinRepository rentJoinRepository;
+    private final MemberRepository memberRepository;
 
     public List<RentSummaryResponse> getRentSummaries(
             final Region region,
@@ -34,9 +39,22 @@ public class RentQueryService {
         return rentRepository.findRentMainSummaries();
     }
 
-    public RentDetailResponse getRentDetailById(final Long id) {
-        return rentRepository.findRentDetailById(id)
+    public RentDetailResponse getRentDetailById(final Long id, final Member member) {
+        RentDetailResponse rentDetailResponse = rentRepository.findRentDetailById(id)
                 .orElseThrow(RentNotFoundException::new);
+        // 만약 회원으로 접속했다면
+        if (member != null) {
+            // 날짜 별 차량 대절 신청 여부 확인
+            rentDetailResponse.getBoardingDates().forEach(response -> {
+                        if (rentJoinRepository.existsByBoardingDateAndRentIdAndMemberId(response.getDate(), id, member.getId()))
+                            response.setIsApplied(true);
+                        else
+                            response.setIsApplied(false);
+            });
+            // 환불 계좌 정보 확인
+            rentDetailResponse.setRefundAccount(member.getRefundAccount());
+        }
+        return rentDetailResponse;
     }
 
     public DepositAccountResponse getDepositAccountById(final Long id) {

--- a/src/main/java/com/backend/allreva/rent/query/application/response/RentDetailResponse.java
+++ b/src/main/java/com/backend/allreva/rent/query/application/response/RentDetailResponse.java
@@ -1,9 +1,11 @@
 package com.backend.allreva.rent.query.application.response;
 
+import com.backend.allreva.member.command.domain.value.RefundAccount;
 import com.backend.allreva.rent.command.domain.value.BusSize;
 import com.backend.allreva.rent.command.domain.value.BusType;
 import com.backend.allreva.rent.command.domain.value.Region;
 import com.backend.allreva.rent_join.command.domain.value.RefundType;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.Getter;
@@ -35,29 +37,32 @@ public class RentDetailResponse {
     private final RefundType refundType; //
     private final String information; // 기타 안내 사항
     private final boolean isClosed; // 마감 여부
+    @Setter
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private RefundAccount refundAccount; // 환불 계좌
 
     public RentDetailResponse(
-            String concertName,
-            String imageUrl,
-            String title,
-            String artistName,
-            Region region,
-            String boardingArea,
-            String dropOffArea,
-            String upTime,
-            String downTime,
-            BusSize busSize,
-            BusType busType,
-            int maxPassenger,
-            int roundPrice,
-            int upTimePrice,
-            int downTimePrice,
-            int recruitmentCount,
-            LocalDate endDate,
-            String chatUrl,
-            RefundType refundType,
-            String information,
-            boolean isClosed
+            final String concertName,
+            final String imageUrl,
+            final String title,
+            final String artistName,
+            final Region region,
+            final String boardingArea,
+            final String dropOffArea,
+            final String upTime,
+            final String downTime,
+            final BusSize busSize,
+            final BusType busType,
+            final int maxPassenger,
+            final int roundPrice,
+            final int upTimePrice,
+            final int downTimePrice,
+            final int recruitmentCount,
+            final LocalDate endDate,
+            final String chatUrl,
+            final RefundType refundType,
+            final String information,
+            final boolean isClosed
     ) {
         this.concertName = concertName;
         this.imageUrl = imageUrl;
@@ -82,10 +87,20 @@ public class RentDetailResponse {
         this.isClosed = isClosed;
     }
 
-    public record RentBoardingDateResponse(
-            LocalDate date,
-            int participationCount
-    ) {
+    @Getter
+    public static class RentBoardingDateResponse {
+        private final LocalDate date;
+        private final int participationCount;
+        @Setter
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        private Boolean isApplied;
 
+        public RentBoardingDateResponse(
+                final LocalDate date,
+                final int participationCount
+        ) {
+            this.date = date;
+            this.participationCount = participationCount;
+        }
     }
 }

--- a/src/main/java/com/backend/allreva/rent/ui/RentController.java
+++ b/src/main/java/com/backend/allreva/rent/ui/RentController.java
@@ -98,9 +98,10 @@ public class RentController implements RentControllerSwagger {
 
     @GetMapping("/{id}")
     public Response<RentDetailResponse> getRentDetailById(
-            @PathVariable final Long id
+            @PathVariable final Long id,
+            @AuthMember final Member member
     ) {
-        return Response.onSuccess(rentQueryService.getRentDetailById(id));
+        return Response.onSuccess(rentQueryService.getRentDetailById(id, member));
     }
 
     @GetMapping("/{id}/deposit-account")

--- a/src/main/java/com/backend/allreva/rent/ui/RentControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/rent/ui/RentControllerSwagger.java
@@ -87,7 +87,8 @@ public interface RentControllerSwagger {
                     endDate는 2024-11-30 과 같은 형태로 반환됩니다.
                     """)
     Response<RentDetailResponse> getRentDetailById(
-            Long id
+            Long id,
+            Member member
     );
 
     @Operation(

--- a/src/main/java/com/backend/allreva/rent_join/command/domain/RentJoinRepository.java
+++ b/src/main/java/com/backend/allreva/rent_join/command/domain/RentJoinRepository.java
@@ -1,6 +1,7 @@
 package com.backend.allreva.rent_join.command.domain;
 
 import com.backend.allreva.rent_join.query.response.RentJoinResponse;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -9,6 +10,8 @@ public interface RentJoinRepository {
     Optional<RentJoin> findById(Long id);
 
     boolean existsById(Long id);
+
+    boolean existsByBoardingDateAndRentIdAndMemberId(LocalDate boardingDate, Long rentId, Long memberId);
 
     RentJoin save(RentJoin rentJoin);
 

--- a/src/main/java/com/backend/allreva/rent_join/infra/RentJoinJpaRepository.java
+++ b/src/main/java/com/backend/allreva/rent_join/infra/RentJoinJpaRepository.java
@@ -1,8 +1,10 @@
 package com.backend.allreva.rent_join.infra;
 
 import com.backend.allreva.rent_join.command.domain.RentJoin;
+import java.time.LocalDate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RentJoinJpaRepository extends JpaRepository<RentJoin, Long> {
 
+    boolean existsByBoardingDateAndRentIdAndMemberId(LocalDate boardingDate, Long rentId, Long memberId);
 }

--- a/src/main/java/com/backend/allreva/rent_join/infra/RentJoinRepositoryImpl.java
+++ b/src/main/java/com/backend/allreva/rent_join/infra/RentJoinRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.backend.allreva.rent_join.infra;
 import com.backend.allreva.rent_join.command.domain.RentJoin;
 import com.backend.allreva.rent_join.command.domain.RentJoinRepository;
 import com.backend.allreva.rent_join.query.response.RentJoinResponse;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,15 @@ public class RentJoinRepositoryImpl implements RentJoinRepository {
     @Override
     public boolean existsById(final Long id) {
         return rentJoinJpaRepository.existsById(id);
+    }
+
+    @Override
+    public boolean existsByBoardingDateAndRentIdAndMemberId(
+            final LocalDate boardingDate,
+            final Long rentId,
+            final Long memberId
+    ) {
+        return rentJoinJpaRepository.existsByBoardingDateAndRentIdAndMemberId(boardingDate, rentId, memberId);
     }
 
     @Override


### PR DESCRIPTION
### 연결된 issue 🌟
- closed #155 

### 구현 내용 📢
#### 신청 여부 및 환불 계좌 조회 기능
차량 대절 상세 조회 시 권한에 따라 결과 값이 다르게 반환되도록 구현했습니다.
- ANONYMOUS: 이전 상세 조회 기능과 동일
- USER: 신청 여부 및 환불 계좌 정보 결과값에 추가

#### Jackson 라이브러리 활용
- @JsonInclude를 활용하여 값이 null일 경우 json 직렬화에 포함되지 않도록 구현했습니다.
- 기존 원시 타입 boolean은 DTO 객체 생성 때 자동으로 false가 할당되었기 때문에, Boolean wrapper 타입을 활용하여 null값을 표현할 수 있도록 했습니다.

#### jpa exists() 활용
신청 여부를 확인하기 위해 각 boardingDate 마다 exists()를 활용하여 rent_join 레코드가 존재하는지 확인했습니다.

JPA에서 MySQL 사용 시 COUNT 대신 LIMIT으로 조회하기 때문에 좀 더 효율적인 조회가 가능합니다. 

### 테스트 결과 🧩
전부 통과됩니다~
