### PR TITLE
[ARV-223] 차량 대절 신청 인원 체크 로직 추가

### DIFF
--- a/src/main/java/com/backend/allreva/rent/command/application/RentCommandService.java
+++ b/src/main/java/com/backend/allreva/rent/command/application/RentCommandService.java
@@ -6,13 +6,18 @@ import com.backend.allreva.rent.command.application.request.RentIdRequest;
 import com.backend.allreva.rent.command.application.request.RentRegisterRequest;
 import com.backend.allreva.rent.command.application.request.RentUpdateRequest;
 import com.backend.allreva.rent.command.domain.Rent;
+import com.backend.allreva.rent.command.domain.RentClosedEvent;
 import com.backend.allreva.rent.command.domain.RentRepository;
 import com.backend.allreva.rent.command.domain.RentSaveEvent;
 import com.backend.allreva.rent.exception.RentNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -53,6 +58,15 @@ public class RentCommandService {
                 .orElseThrow(RentNotFoundException::new);
 
         rent.validateMine(memberId);
+        rent.close();
+    }
+
+    @Async
+    @TransactionalEventListener
+    public void closeRent(RentClosedEvent event) {
+        Rent rent = rentRepository.findById(event.getRentId())
+                .orElseThrow(RentNotFoundException::new);
+
         rent.close();
     }
 

--- a/src/main/java/com/backend/allreva/rent/command/domain/RentClosedEvent.java
+++ b/src/main/java/com/backend/allreva/rent/command/domain/RentClosedEvent.java
@@ -1,0 +1,17 @@
+package com.backend.allreva.rent.command.domain;
+
+import com.backend.allreva.common.event.Event;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RentClosedEvent extends Event {
+
+    private Long rentId;
+
+    public RentClosedEvent(Long rentId) {
+        this.rentId = rentId;
+    }
+}

--- a/src/main/java/com/backend/allreva/rent/exception/RentErrorCode.java
+++ b/src/main/java/com/backend/allreva/rent/exception/RentErrorCode.java
@@ -11,7 +11,8 @@ public enum RentErrorCode implements ErrorCodeInterface {
     RENT_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "RENT_ACCESS_DENIED", "차 대절 폼에 접근할 수 없습니다."),
     RENT_JOIN_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "RENT_JOIN_NOT_FOUND", "존재하지 않는 차 대절 참석 폼입니다."),
     RENT_JOIN_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "RENT_JOIN_ACCESS_DENIED", "차 대절 참석 폼에 접근할 수 없습니다."),
-    PASSENGERS_MAXIMUM_REACHED(HttpStatus.BAD_REQUEST.value(), "PASSENGERS_MAXIMUN_REACHED", "차 대절 폼의 최대 인원을 초과했습니다."),
+    RENT_JOIN_ALREADY_EXISTS(HttpStatus.BAD_REQUEST.value(), "RENT_JOIN_ALREADY_EXISTS", "이미 해당 차 대절 폼에 참석했습니다."),
+    PASSENGERS_MAXIMUM_REACHED(HttpStatus.BAD_REQUEST.value(), "PASSENGERS_MAXIMUM_REACHED", "차 대절 폼의 최대 인원을 초과했습니다."),
     ;
 
     private final Integer status;

--- a/src/main/java/com/backend/allreva/rent/exception/RentErrorCode.java
+++ b/src/main/java/com/backend/allreva/rent/exception/RentErrorCode.java
@@ -10,7 +10,8 @@ public enum RentErrorCode implements ErrorCodeInterface {
     RENT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "RENT_NOT_FOUND", "존재하지 않는 차 대절 폼입니다."),
     RENT_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "RENT_ACCESS_DENIED", "차 대절 폼에 접근할 수 없습니다."),
     RENT_JOIN_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "RENT_JOIN_NOT_FOUND", "존재하지 않는 차 대절 참석 폼입니다."),
-    RENT_JOIN_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "RENT_JOIN_ACCESS_DENIED", "차 대절 참석 폼에 접근할 수 없습니다.")
+    RENT_JOIN_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "RENT_JOIN_ACCESS_DENIED", "차 대절 참석 폼에 접근할 수 없습니다."),
+    PASSENGERS_MAXIMUM_REACHED(HttpStatus.BAD_REQUEST.value(), "PASSENGERS_MAXIMUN_REACHED", "차 대절 폼의 최대 인원을 초과했습니다."),
     ;
 
     private final Integer status;

--- a/src/main/java/com/backend/allreva/rent_join/command/application/RentJoinCommandService.java
+++ b/src/main/java/com/backend/allreva/rent_join/command/application/RentJoinCommandService.java
@@ -9,6 +9,7 @@ import com.backend.allreva.rent_join.command.application.request.RentJoinUpdateR
 import com.backend.allreva.rent_join.command.domain.RentJoin;
 import com.backend.allreva.rent_join.command.domain.RentJoinRepository;
 import com.backend.allreva.rent_join.exception.PassengersMaximumReachedException;
+import com.backend.allreva.rent_join.exception.RentJoinAlreadyExistsException;
 import com.backend.allreva.rent_join.exception.RentJoinNotFoundException;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,16 @@ public class RentJoinCommandService {
             final RentJoinApplyRequest rentJoinApplyRequest,
             final Long memberId
     ) {
+        // check if the user has already applied
+        if (rentJoinRepository.existsByBoardingDateAndRentIdAndMemberId(
+                rentJoinApplyRequest.boardingDate(),
+                rentJoinApplyRequest.rentId(),
+                memberId
+        )) {
+            throw new RentJoinAlreadyExistsException();
+        }
+
+        // if the number of passengers exceeds
         checkPassengersMaximumReached(
                 rentJoinApplyRequest.rentId(),
                 rentJoinApplyRequest.boardingDate(),
@@ -68,7 +79,6 @@ public class RentJoinCommandService {
             final LocalDate boardingDate,
             final Integer passengerNum
     ) {
-        // if the number of passengers exceeds
         Rent rent = rentRepository.findById(rentId)
                 .orElseThrow(RentNotFoundException::new);
         int maximumCount = rent.getAdditionalInfo().getRecruitmentCount();

--- a/src/main/java/com/backend/allreva/rent_join/command/application/RentJoinCommandService.java
+++ b/src/main/java/com/backend/allreva/rent_join/command/application/RentJoinCommandService.java
@@ -1,17 +1,24 @@
 package com.backend.allreva.rent_join.command.application;
 
+import com.backend.allreva.rent.command.domain.Rent;
 import com.backend.allreva.rent.command.domain.RentRepository;
-import com.backend.allreva.rent_join.exception.RentJoinNotFoundException;
 import com.backend.allreva.rent.exception.RentNotFoundException;
 import com.backend.allreva.rent_join.command.application.request.RentJoinApplyRequest;
 import com.backend.allreva.rent_join.command.application.request.RentJoinIdRequest;
 import com.backend.allreva.rent_join.command.application.request.RentJoinUpdateRequest;
 import com.backend.allreva.rent_join.command.domain.RentJoin;
 import com.backend.allreva.rent_join.command.domain.RentJoinRepository;
+import com.backend.allreva.rent_join.exception.PassengersMaximumReachedException;
+import com.backend.allreva.rent_join.exception.RentJoinNotFoundException;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @RequiredArgsConstructor
+@Transactional
 @Service
 public class RentJoinCommandService {
 
@@ -22,10 +29,11 @@ public class RentJoinCommandService {
             final RentJoinApplyRequest rentJoinApplyRequest,
             final Long memberId
     ) {
-        // 한방쿼리 작성??
-        if (!rentRepository.existsById(rentJoinApplyRequest.rentId())) {
-            throw new RentNotFoundException();
-        }
+        checkPassengersMaximumReached(
+                rentJoinApplyRequest.rentId(),
+                rentJoinApplyRequest.boardingDate(),
+                rentJoinApplyRequest.passengerNum()
+        );
 
         RentJoin rentJoin = rentJoinApplyRequest.toEntity(memberId);
 
@@ -53,5 +61,21 @@ public class RentJoinCommandService {
 
         rentJoin.validateMine(memberId);
         rentJoinRepository.delete(rentJoin);
+    }
+
+    private void checkPassengersMaximumReached(
+            final Long rentId,
+            final LocalDate boardingDate,
+            final Integer passengerNum
+    ) {
+        // if the number of passengers exceeds
+        Rent rent = rentRepository.findById(rentId)
+                .orElseThrow(RentNotFoundException::new);
+        int maximumCount = rent.getAdditionalInfo().getRecruitmentCount();
+
+        Integer currentPassengerCount = rentJoinRepository.countRentJoin(rentId, boardingDate);
+        if (currentPassengerCount + passengerNum > maximumCount) {
+            throw new PassengersMaximumReachedException();
+        }
     }
 }

--- a/src/main/java/com/backend/allreva/rent_join/command/application/RentJoinCommandService.java
+++ b/src/main/java/com/backend/allreva/rent_join/command/application/RentJoinCommandService.java
@@ -1,6 +1,8 @@
 package com.backend.allreva.rent_join.command.application;
 
+import com.backend.allreva.common.event.Events;
 import com.backend.allreva.rent.command.domain.Rent;
+import com.backend.allreva.rent.command.domain.RentClosedEvent;
 import com.backend.allreva.rent.command.domain.RentRepository;
 import com.backend.allreva.rent.exception.RentNotFoundException;
 import com.backend.allreva.rent_join.command.application.request.RentJoinApplyRequest;
@@ -86,6 +88,10 @@ public class RentJoinCommandService {
         Integer currentPassengerCount = rentJoinRepository.countRentJoin(rentId, boardingDate);
         if (currentPassengerCount + passengerNum > maximumCount) {
             throw new PassengersMaximumReachedException();
+        }
+        // rent close event
+        if (currentPassengerCount + passengerNum == maximumCount) {
+            Events.raise(new RentClosedEvent(rentId));
         }
     }
 }

--- a/src/main/java/com/backend/allreva/rent_join/command/application/request/RentJoinApplyRequest.java
+++ b/src/main/java/com/backend/allreva/rent_join/command/application/request/RentJoinApplyRequest.java
@@ -40,6 +40,7 @@ public record RentJoinApplyRequest(
                         .phone(phone)
                         .build())
                 .boardingType(boardingType)
+                .passengerNum(passengerNum)
                 .refundType(refundType)
                 .refundAccount(refundAccount)
                 .boardingDate(boardingDate)

--- a/src/main/java/com/backend/allreva/rent_join/command/domain/RentJoinRepository.java
+++ b/src/main/java/com/backend/allreva/rent_join/command/domain/RentJoinRepository.java
@@ -9,6 +9,8 @@ public interface RentJoinRepository {
 
     Optional<RentJoin> findById(Long id);
 
+    Integer countRentJoin(Long rentId, LocalDate boardingDate);
+
     boolean existsById(Long id);
 
     boolean existsByBoardingDateAndRentIdAndMemberId(LocalDate boardingDate, Long rentId, Long memberId);

--- a/src/main/java/com/backend/allreva/rent_join/exception/PassengersMaximumReachedException.java
+++ b/src/main/java/com/backend/allreva/rent_join/exception/PassengersMaximumReachedException.java
@@ -1,0 +1,11 @@
+package com.backend.allreva.rent_join.exception;
+
+import com.backend.allreva.common.exception.CustomException;
+import com.backend.allreva.rent.exception.RentErrorCode;
+
+public class PassengersMaximumReachedException extends CustomException {
+
+    public PassengersMaximumReachedException() {
+        super(RentErrorCode.PASSENGERS_MAXIMUM_REACHED);
+    }
+}

--- a/src/main/java/com/backend/allreva/rent_join/exception/RentJoinAlreadyExistsException.java
+++ b/src/main/java/com/backend/allreva/rent_join/exception/RentJoinAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package com.backend.allreva.rent_join.exception;
+
+import com.backend.allreva.common.exception.CustomException;
+import com.backend.allreva.rent.exception.RentErrorCode;
+
+public class RentJoinAlreadyExistsException extends CustomException {
+
+    public RentJoinAlreadyExistsException() {
+        super(RentErrorCode.RENT_JOIN_ALREADY_EXISTS);
+    }
+}

--- a/src/main/java/com/backend/allreva/rent_join/infra/RentJoinDslRepository.java
+++ b/src/main/java/com/backend/allreva/rent_join/infra/RentJoinDslRepository.java
@@ -12,6 +12,7 @@ import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -21,6 +22,24 @@ import org.springframework.stereotype.Repository;
 public class RentJoinDslRepository {
 
     private final JPAQueryFactory queryFactory;
+
+    /**
+     * [Count] 차 대절 현재 참여자 수 조회
+     */
+    public Integer countRentJoin(
+            final Long rentId,
+            final LocalDate boardingDate
+    ) {
+        return queryFactory.select(rentJoin.passengerNum.sum().coalesce(0))
+                .from(rentJoin)
+                .leftJoin(rentBoardingDate)
+                    .on(rentBoardingDate.rent.id.eq(rentJoin.rentId))
+                .where(
+                        rentJoin.rentId.eq(rentId),
+                        rentJoin.boardingDate.eq(boardingDate)
+                )
+                .fetchOne();
+    }
 
     /**
      * [Participate] 자신이 참여한 차 대절 조회

--- a/src/main/java/com/backend/allreva/rent_join/infra/RentJoinRepositoryImpl.java
+++ b/src/main/java/com/backend/allreva/rent_join/infra/RentJoinRepositoryImpl.java
@@ -22,6 +22,14 @@ public class RentJoinRepositoryImpl implements RentJoinRepository {
     }
 
     @Override
+    public Integer countRentJoin(
+            final Long rentId,
+            final LocalDate boardingDate
+    ) {
+        return rentJoinDslRepository.countRentJoin(rentId, boardingDate);
+    }
+
+    @Override
     public boolean existsById(final Long id) {
         return rentJoinJpaRepository.existsById(id);
     }

--- a/src/main/java/com/backend/allreva/rent_join/ui/RentJoinController.java
+++ b/src/main/java/com/backend/allreva/rent_join/ui/RentJoinController.java
@@ -10,6 +10,7 @@ import com.backend.allreva.rent_join.command.application.request.RentJoinUpdateR
 import com.backend.allreva.rent_join.query.RentJoinQueryService;
 import com.backend.allreva.rent_join.query.response.RentJoinResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -17,6 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/rents")
 @RestController
+@Validated
 public class RentJoinController implements RentJoinControllerSwagger{
 
     private final RentJoinCommandService rentJoinCommandService;


### PR DESCRIPTION
### 연결된 issue 🌟
- closed #206 

### 구현 내용 📢
### 1. 차량 대절을 이미 신청했다면 재신청 불가
차량 대절을 이미 신청한 인원이 같은 차량 대절을 다시 신청할 수 없도록 구현

### 2. 차량 대절 신청할 시, 신청 인원이 넘는다면 에러 응답
`PassengersMaximumReachedException()`이 발생합니다.

### 3. 차량 대절 신청 인원이 꽉 찼다면 자동으로 close하도록 이벤트 발행
- 해당 이벤트는 트랜잭션 커밋 이후로 실행
- close시 엘라스틱 서치로 Delete 이벤트가 전달되어 차량 대절 검색에서 제외되도록 구현

다음은 관련 코드 입니다.
```java
    public Long applyRent(
            final RentJoinApplyRequest rentJoinApplyRequest,
            final Long memberId
    ) {
        // check if the user has already applied
        if (rentJoinRepository.existsByBoardingDateAndRentIdAndMemberId(
                rentJoinApplyRequest.boardingDate(),
                rentJoinApplyRequest.rentId(),
                memberId
        )) {
            throw new RentJoinAlreadyExistsException();
        }

        // if the number of passengers exceeds
        checkPassengersMaximumReached(
                rentJoinApplyRequest.rentId(),
                rentJoinApplyRequest.boardingDate(),
                rentJoinApplyRequest.passengerNum()
        );

        RentJoin rentJoin = rentJoinApplyRequest.toEntity(memberId);

        RentJoin savedRentJoin = rentJoinRepository.save(rentJoin);
        return savedRentJoin.getId();
    }

    private void checkPassengersMaximumReached(
            final Long rentId,
            final LocalDate boardingDate,
            final Integer passengerNum
    ) {
        Rent rent = rentRepository.findById(rentId)
                .orElseThrow(RentNotFoundException::new);
        int maximumCount = rent.getAdditionalInfo().getRecruitmentCount();

        Integer currentPassengerCount = rentJoinRepository.countRentJoin(rentId, boardingDate);
        if (currentPassengerCount + passengerNum > maximumCount) {
            throw new PassengersMaximumReachedException();
        }
        // rent close event
        if (currentPassengerCount + passengerNum == maximumCount) {
            Events.raise(new RentClosedEvent(rentId));
        }
    }
```

### 테스트 결과 🧩
모두 정상으로 통과합니다.


### 리뷰 포인트 📌
### close 이벤트 실행 시 트랜잭션 관련
트랜잭션 commit 이후로 close 로직이 비동기로 실행된다면, 동시성이 보장되는지 의견 나누고 싶습니다..!
