### PR TITLE
Cookie domain 확인 로직 추가

### DIFF
--- a/src/main/java/com/backend/allreva/auth/application/CookieService.java
+++ b/src/main/java/com/backend/allreva/auth/application/CookieService.java
@@ -11,7 +11,7 @@ public class CookieService {
     @Value("${jwt.refresh.expiration}")
     private int refreshTime;
     @Value("${url.front.domain-name}")
-    private String domainName;
+    private String prodDomainName;
 
     public void addRefreshTokenCookie(
             final HttpServletResponse response,
@@ -20,10 +20,14 @@ public class CookieService {
     ) {
         CookieUtils.addCookie(
                 response,
-                domainName,
+                isLocalhost(domainName) ? null : prodDomainName,
                 "refreshToken",
                 refreshToken,
                 refreshTime
         );
+    }
+
+    private static boolean isLocalhost(String domain) {
+        return domain.equals("localhost");
     }
 }

--- a/src/main/java/com/backend/allreva/auth/application/CookieService.java
+++ b/src/main/java/com/backend/allreva/auth/application/CookieService.java
@@ -15,7 +15,8 @@ public class CookieService {
 
     public void addRefreshTokenCookie(
             final HttpServletResponse response,
-            final String refreshToken
+            final String refreshToken,
+            final String domainName
     ) {
         CookieUtils.addCookie(
                 response,

--- a/src/main/java/com/backend/allreva/auth/ui/AuthController.java
+++ b/src/main/java/com/backend/allreva/auth/ui/AuthController.java
@@ -27,7 +27,7 @@ public class AuthController implements AuthControllerSwagger {
             final HttpServletRequest request,
             final HttpServletResponse response
     ) {
-        String domainName = request.getServerName();
+        String domainName = request.getServerName(); // localhost 확인 용도
         UserInfoResponse userInfoResponse = authService.kakaoLogin(authorizationCode);
         if (userInfoResponse.isUser()) {
             cookieService.addRefreshTokenCookie(response, userInfoResponse.refreshToken(), domainName);

--- a/src/main/java/com/backend/allreva/auth/ui/AuthController.java
+++ b/src/main/java/com/backend/allreva/auth/ui/AuthController.java
@@ -4,6 +4,7 @@ import com.backend.allreva.auth.application.AuthService;
 import com.backend.allreva.auth.application.CookieService;
 import com.backend.allreva.auth.application.dto.UserInfoResponse;
 import com.backend.allreva.common.dto.Response;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -23,11 +24,13 @@ public class AuthController implements AuthControllerSwagger {
     @GetMapping("/token/kakao")
     public Response<UserInfoResponse> authKakaoLogin(
             @RequestParam("code") final String authorizationCode,
+            final HttpServletRequest request,
             final HttpServletResponse response
     ) {
+        String domainName = request.getServerName();
         UserInfoResponse userInfoResponse = authService.kakaoLogin(authorizationCode);
         if (userInfoResponse.isUser()) {
-            cookieService.addRefreshTokenCookie(response, userInfoResponse.refreshToken());
+            cookieService.addRefreshTokenCookie(response, userInfoResponse.refreshToken(), domainName);
             response.addHeader("Authorization", "Bearer " + userInfoResponse.accessToken());
         }
         return Response.onSuccess(userInfoResponse);
@@ -36,10 +39,12 @@ public class AuthController implements AuthControllerSwagger {
     @GetMapping("/token/reissue")
     public Response<Void> reissueToken(
             @CookieValue(name = "refreshToken", required = false) final String refreshToken,
+            final HttpServletRequest request,
             final HttpServletResponse response
     ) {
+        String domainName = request.getServerName();
         UserInfoResponse userInfoResponse = authService.reissueAccessToken(refreshToken);
-        cookieService.addRefreshTokenCookie(response, userInfoResponse.refreshToken());
+        cookieService.addRefreshTokenCookie(response, userInfoResponse.refreshToken(), domainName);
         response.addHeader("Authorization", "Bearer " + userInfoResponse.accessToken());
         return Response.onSuccess();
     }
@@ -47,10 +52,12 @@ public class AuthController implements AuthControllerSwagger {
     @GetMapping("/login/check")
     public Response<UserInfoResponse> loginCheck(
             @CookieValue(name = "refreshToken", required = false) final String refreshToken,
+            final HttpServletRequest request,
             final HttpServletResponse response
     ) {
+        String domainName = request.getServerName();
         UserInfoResponse userInfoResponse = authService.reissueAccessToken(refreshToken);
-        cookieService.addRefreshTokenCookie(response, userInfoResponse.refreshToken());
+        cookieService.addRefreshTokenCookie(response, userInfoResponse.refreshToken(), domainName);
         response.addHeader("Authorization", "Bearer " + userInfoResponse.accessToken());
         return Response.onSuccess(userInfoResponse);
     }

--- a/src/main/java/com/backend/allreva/auth/ui/AuthController.java
+++ b/src/main/java/com/backend/allreva/auth/ui/AuthController.java
@@ -4,6 +4,7 @@ import com.backend.allreva.auth.application.AuthService;
 import com.backend.allreva.auth.application.CookieService;
 import com.backend.allreva.auth.application.dto.UserInfoResponse;
 import com.backend.allreva.common.dto.Response;
+import com.backend.allreva.common.util.DomainUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +28,7 @@ public class AuthController implements AuthControllerSwagger {
             final HttpServletRequest request,
             final HttpServletResponse response
     ) {
-        String domainName = request.getServerName(); // localhost 확인 용도
+        String domainName = DomainUtils.getDomainName(request);
         UserInfoResponse userInfoResponse = authService.kakaoLogin(authorizationCode);
         if (userInfoResponse.isUser()) {
             cookieService.addRefreshTokenCookie(response, userInfoResponse.refreshToken(), domainName);
@@ -42,7 +43,7 @@ public class AuthController implements AuthControllerSwagger {
             final HttpServletRequest request,
             final HttpServletResponse response
     ) {
-        String domainName = request.getServerName();
+        String domainName = DomainUtils.getDomainName(request);
         UserInfoResponse userInfoResponse = authService.reissueAccessToken(refreshToken);
         cookieService.addRefreshTokenCookie(response, userInfoResponse.refreshToken(), domainName);
         response.addHeader("Authorization", "Bearer " + userInfoResponse.accessToken());
@@ -55,7 +56,7 @@ public class AuthController implements AuthControllerSwagger {
             final HttpServletRequest request,
             final HttpServletResponse response
     ) {
-        String domainName = request.getServerName();
+        String domainName = DomainUtils.getDomainName(request);
         UserInfoResponse userInfoResponse = authService.reissueAccessToken(refreshToken);
         cookieService.addRefreshTokenCookie(response, userInfoResponse.refreshToken(), domainName);
         response.addHeader("Authorization", "Bearer " + userInfoResponse.accessToken());

--- a/src/main/java/com/backend/allreva/auth/ui/AuthControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/auth/ui/AuthControllerSwagger.java
@@ -4,6 +4,7 @@ import com.backend.allreva.auth.application.dto.UserInfoResponse;
 import com.backend.allreva.common.dto.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 @Tag(name = "회원 인증 및 인가 API", description = "인증 및 인가를 처리합니다")
@@ -13,18 +14,21 @@ public interface AuthControllerSwagger {
             + "먼저 카카오 로그인을 한 후에 authorization code를 받아서 이를 파라미터로 넘겨야 합니다.")
     Response<UserInfoResponse> authKakaoLogin(
             String authorizationCode,
+            HttpServletRequest request,
             HttpServletResponse response
     );
 
     @Operation(summary = "access token 재발급 요청", description = "refresh token을 이용하여 access token을 재발급합니다.")
     Response<Void> reissueToken(
             String refreshToken,
+            HttpServletRequest request,
             HttpServletResponse response
     );
 
     @Operation(summary = "로그인 체크", description = "refresh token을 이용하여 access token을 재발급합니다.")
     Response<UserInfoResponse> loginCheck(
             String refreshToken,
+            HttpServletRequest request,
             HttpServletResponse response
     );
 }

--- a/src/main/java/com/backend/allreva/common/util/CookieUtils.java
+++ b/src/main/java/com/backend/allreva/common/util/CookieUtils.java
@@ -18,7 +18,7 @@ public final class CookieUtils {
             final int maxAge
     ) {
         ResponseCookie cookie = ResponseCookie.from(name, value)
-                .domain(isLocalhost(cookieDomain) ? null : cookieDomain)
+                .domain(cookieDomain)
                 .path("/")
                 .maxAge(maxAge)
                 .httpOnly(true)
@@ -27,9 +27,5 @@ public final class CookieUtils {
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
-    }
-
-    private static boolean isLocalhost(String domain) {
-        return domain.equals("localhost");
     }
 }

--- a/src/main/java/com/backend/allreva/common/util/DomainUtils.java
+++ b/src/main/java/com/backend/allreva/common/util/DomainUtils.java
@@ -1,0 +1,20 @@
+package com.backend.allreva.common.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public final class DomainUtils {
+
+    public static String getDomainName(HttpServletRequest request) {
+        // 1️Nginx 프록시를 고려하여 먼저 `Host` 헤더 확인
+        String domainName = request.getHeader("Host");
+
+        // 2️만약 `Host` 헤더가 없으면 로컬 환경이므로 `request.getServerName()` 사용
+        if (domainName == null || domainName.isEmpty()) {
+            domainName = request.getServerName(); // 로컬에서는 "localhost"
+        }
+
+        return domainName;
+    }
+}


### PR DESCRIPTION
### 연결된 issue 🌟
- closed #220 

### 구현 내용 📢
### 요청 domain name 확인 로직 추가

- `CookieService` 에서 localhost인지 확인 후 맞다면 null값을, 아니면 yml에서 설정한 `url.front.domain-name`값을 넣도록 수정

```java
@GetMapping("/token/kakao")
public Response<UserInfoResponse> authKakaoLogin(
        @RequestParam("code") final String authorizationCode,
        final HttpServletRequest request,
        final HttpServletResponse response
) {
    String domainName = request.getServerName(); // localhost 확인 용도
    UserInfoResponse userInfoResponse = authService.kakaoLogin(authorizationCode);
    if (userInfoResponse.isUser()) {
        cookieService.addRefreshTokenCookie(response, userInfoResponse.refreshToken(), domainName);
        response.addHeader("Authorization", "Bearer " + userInfoResponse.accessToken());
    }
    return Response.onSuccess(userInfoResponse);
}
```

```java
@Service
public class CookieService {

    @Value("${jwt.refresh.expiration}")
    private int refreshTime;
    @Value("${url.front.domain-name}")
    private String prodDomainName;

    public void addRefreshTokenCookie(
            final HttpServletResponse response,
            final String refreshToken,
            final String domainName
    ) {
        CookieUtils.addCookie(
                response,
                isLocalhost(domainName) ? null : prodDomainName,
                "refreshToken",
                refreshToken,
                refreshTime
        );
    }

    private static boolean isLocalhost(String domain) {
        return domain.equals("localhost");
    }
}
```

### 테스트 결과 🧩
정상입니다.

