### PR TITLE
[#220] kakao oauth2 redirect url에서 localhost 판별 로직 추가

### DIFF
--- a/src/main/java/com/backend/allreva/auth/application/AuthService.java
+++ b/src/main/java/com/backend/allreva/auth/application/AuthService.java
@@ -27,8 +27,11 @@ public class AuthService {
      * @param authorizationCode 인가 코드
      * @return 로그인 응답
      */
-    public UserInfoResponse kakaoLogin(final String authorizationCode) {
-        UserInfo userInfo = oAuth2LoginService.getUserInfo(authorizationCode);
+    public UserInfoResponse kakaoLogin(
+            final String authorizationCode,
+            final String domainName
+    ) {
+        UserInfo userInfo = oAuth2LoginService.getUserInfo(authorizationCode, domainName);
 
         // 회원 존재 확인
         Email emailVO = Email.builder()

--- a/src/main/java/com/backend/allreva/auth/application/OAuth2LoginService.java
+++ b/src/main/java/com/backend/allreva/auth/application/OAuth2LoginService.java
@@ -4,5 +4,5 @@ import com.backend.allreva.auth.application.dto.UserInfo;
 
 public interface OAuth2LoginService {
 
-    UserInfo getUserInfo(String authorizationCode);
+    UserInfo getUserInfo(String authorizationCode, String domainName);
 }

--- a/src/main/java/com/backend/allreva/auth/exception/code/InvalidRedirectUrlException.java
+++ b/src/main/java/com/backend/allreva/auth/exception/code/InvalidRedirectUrlException.java
@@ -1,0 +1,10 @@
+package com.backend.allreva.auth.exception.code;
+
+import com.backend.allreva.common.exception.CustomException;
+
+public class InvalidRedirectUrlException extends CustomException {
+
+    public InvalidRedirectUrlException() {
+        super(OAuth2ErrorCode.INVALID_REDIRECT_URI);
+    }
+}

--- a/src/main/java/com/backend/allreva/auth/exception/code/OAuth2ErrorCode.java
+++ b/src/main/java/com/backend/allreva/auth/exception/code/OAuth2ErrorCode.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 public enum OAuth2ErrorCode implements ErrorCodeInterface {
 
     UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST.value(), "UNSUPPORTED_PROVIDER", "지원하지 않는 provider 입니다."),
+    INVALID_REDIRECT_URI(HttpStatus.BAD_REQUEST.value(), "INVALID_REDIRECT_URI", "유효하지 않은 redirect uri 입니다."),
     ;
 
     private final Integer status;

--- a/src/main/java/com/backend/allreva/auth/oauth2/KakaoOAuth2LoginService.java
+++ b/src/main/java/com/backend/allreva/auth/oauth2/KakaoOAuth2LoginService.java
@@ -2,11 +2,15 @@ package com.backend.allreva.auth.oauth2;
 
 import com.backend.allreva.auth.application.OAuth2LoginService;
 import com.backend.allreva.auth.application.dto.UserInfo;
+import com.backend.allreva.auth.exception.code.InvalidRedirectUrlException;
 import com.backend.allreva.member.command.domain.value.LoginProvider;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class KakaoOAuth2LoginService implements OAuth2LoginService {
@@ -14,6 +18,10 @@ public class KakaoOAuth2LoginService implements OAuth2LoginService {
     private final KakaoAuthClient kakaoAuthClient;
     private final KakaoUserInfoClient kakaoUserInfoClient;
 
+    @Value("${url.front.domain-name}")
+    private String prodDomainName;
+    @Value("${oauth2.kakao.local-redirect-uri}")
+    private String kakaoLocalRedirectUri;
     @Value("${oauth2.kakao.redirect-uri}")
     private String kakaoRedirectUri;
     @Value("${oauth2.kakao.client-id}")
@@ -27,10 +35,16 @@ public class KakaoOAuth2LoginService implements OAuth2LoginService {
      * @return 사용자 정보
      */
     @Override
-    public UserInfo getUserInfo(final String authorizationCode) {
+    public UserInfo getUserInfo(
+            final String authorizationCode,
+            final String domainName
+    ) {
+        log.info("domainName: {}", domainName);
+        log.info("prodDomainName: {}", prodDomainName);
+        String redirectUri = getRedirectUri(domainName); // localhost or prod
         KakaoToken token = kakaoAuthClient.getToken(
                 kakaoClientId,
-                kakaoRedirectUri,
+                redirectUri,
                 authorizationCode,
                 "authorization_code",
                 kakaoClientSecret
@@ -47,5 +61,15 @@ public class KakaoOAuth2LoginService implements OAuth2LoginService {
                 .nickname(kakaoUserInfo.kakaoAccount().profile().nickname())
                 .profileImageUrl(kakaoUserInfo.kakaoAccount().profile().profileImageUrl())
                 .build();
+    }
+
+    private String getRedirectUri(final String domainName) {
+        if (Objects.equals("localhost", domainName)) {
+            return kakaoLocalRedirectUri;
+        }
+        if (Objects.equals(prodDomainName, domainName)) {
+            return kakaoRedirectUri;
+        }
+        throw new InvalidRedirectUrlException();
     }
 }

--- a/src/main/java/com/backend/allreva/auth/ui/AuthController.java
+++ b/src/main/java/com/backend/allreva/auth/ui/AuthController.java
@@ -29,7 +29,7 @@ public class AuthController implements AuthControllerSwagger {
             final HttpServletResponse response
     ) {
         String domainName = DomainUtils.getDomainName(request);
-        UserInfoResponse userInfoResponse = authService.kakaoLogin(authorizationCode);
+        UserInfoResponse userInfoResponse = authService.kakaoLogin(authorizationCode, domainName);
         if (userInfoResponse.isUser()) {
             cookieService.addRefreshTokenCookie(response, userInfoResponse.refreshToken(), domainName);
             response.addHeader("Authorization", "Bearer " + userInfoResponse.accessToken());

--- a/src/main/java/com/backend/allreva/common/util/DomainUtils.java
+++ b/src/main/java/com/backend/allreva/common/util/DomainUtils.java
@@ -9,14 +9,16 @@ import lombok.extern.slf4j.Slf4j;
 public final class DomainUtils {
 
     public static String getDomainName(HttpServletRequest request) {
-        // 1️Nginx 프록시를 고려하여 먼저 `Host` 헤더 확인
+        //  ️Nginx 프록시를 고려하여 먼저 `Host` 헤더 확인
         String domainName = request.getHeader("Host");
         log.info("Host: {}", domainName);
 
-        // 2️만약 `Host` 헤더가 없으면 로컬 환경이므로 `request.getServerName()` 사용
+        // 만약 `Host` 헤더가 없으면 로컬 환경이므로 `request.getServerName()` 사용
         if (domainName == null || domainName.isEmpty()) {
             domainName = request.getServerName(); // 로컬에서는 "localhost"
             log.info("ServerName: {}", domainName);
+        } else {
+            domainName = domainName.split(":")[0]; // localhost 및 ip 경우 포트 번호 제거
         }
 
         return domainName;

--- a/src/main/java/com/backend/allreva/common/util/DomainUtils.java
+++ b/src/main/java/com/backend/allreva/common/util/DomainUtils.java
@@ -2,17 +2,21 @@ package com.backend.allreva.common.util;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public final class DomainUtils {
 
     public static String getDomainName(HttpServletRequest request) {
         // 1️Nginx 프록시를 고려하여 먼저 `Host` 헤더 확인
         String domainName = request.getHeader("Host");
+        log.info("Host: {}", domainName);
 
         // 2️만약 `Host` 헤더가 없으면 로컬 환경이므로 `request.getServerName()` 사용
         if (domainName == null || domainName.isEmpty()) {
             domainName = request.getServerName(); // 로컬에서는 "localhost"
+            log.info("ServerName: {}", domainName);
         }
 
         return domainName;


### PR DESCRIPTION
### 연결된 issue 🌟
- closed #220 

### 구현 내용 📢
### 환경에 따른 환경변수 의존도 낮추기
환경에 따라 `localhost` 혹은 `example.com` url을 다르게 설정해야 하기 때문에, 서버 1개의 환경에서는 테스트 하기 번거로운 문제.

특히 배포 환경으로 테스트하기 위해서는 서버를 재배포 해야 했으며, 프론트 측에서는 로컬 개발이 불가능.

그래서 다음과 같이 변경. 해당 PR은 oauth2 redirect url 변경에 해당.
```java
private String getRedirectUri(final String domainName) {
    if (Objects.equals("localhost", domainName)) {
        return kakaoLocalRedirectUri;
    }
    if (Objects.equals(prodDomainName, domainName)) {
        return kakaoRedirectUri;
    }
    throw new InvalidRedirectUrlException();
}
```

### ❗cd.yml이 업데이트 되었습니다!
```
oauth2:
  kakao:
    local-redirect-uri: https://localhost:3000/signup/callback
    redirect-uri: https://allreva.store/signup/callback
```
다음과 같이 업데이트 되었습니다!

자세한 사항은 노션 참고해주세요

### 테스트 결과 🧩
정상입니당
