### PR TITLE
로그아웃 API 구현 및 domain Host name 추출 수정

### DIFF
--- a/src/main/java/com/backend/allreva/auth/application/AuthService.java
+++ b/src/main/java/com/backend/allreva/auth/application/AuthService.java
@@ -110,4 +110,18 @@ public class AuthService {
                 .profileImageUrl(member.getMemberInfo().getProfileImageUrl())
                 .build();
     }
+
+    /**
+     * Redis에 저장된 Refresh Token을 제거합니다.
+     */
+    public void logout(final String refreshToken) {
+        if (refreshToken == null) {
+            throw new TokenEmptyException();
+        }
+
+        // redis refresh token은 따로 만료기간이 없어서 영구 저장됨 -> 없다면 문제 있는거.
+        jwtService.validRefreshTokenExistInRedis(refreshToken);
+
+        jwtService.deleteRefreshTokenInRedis(refreshToken);
+    }
 }

--- a/src/main/java/com/backend/allreva/auth/application/CookieService.java
+++ b/src/main/java/com/backend/allreva/auth/application/CookieService.java
@@ -27,6 +27,17 @@ public class CookieService {
         );
     }
 
+    public void deleteRefreshTokenCookie(
+            final HttpServletResponse response,
+            final String domainName
+    ) {
+        CookieUtils.deleteCookie(
+                response,
+                isLocalhost(domainName) ? null : prodDomainName,
+                "refreshToken"
+        );
+    }
+
     private static boolean isLocalhost(String domain) {
         return domain.contains("localhost");
     }

--- a/src/main/java/com/backend/allreva/auth/application/CookieService.java
+++ b/src/main/java/com/backend/allreva/auth/application/CookieService.java
@@ -2,6 +2,8 @@ package com.backend.allreva.auth.application;
 
 import com.backend.allreva.common.util.CookieUtils;
 import jakarta.servlet.http.HttpServletResponse;
+import java.net.MalformedURLException;
+import java.net.URL;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -39,6 +41,12 @@ public class CookieService {
     }
 
     private static boolean isLocalhost(String domain) {
-        return domain.contains("localhost");
+        try {
+            URL url = new URL(domain);
+            String host = url.getHost();
+            return host.contains("localhost") || host.contains("127.0.0.1");
+        } catch (MalformedURLException e) {
+            return false;
+        }
     }
 }

--- a/src/main/java/com/backend/allreva/auth/application/JwtService.java
+++ b/src/main/java/com/backend/allreva/auth/application/JwtService.java
@@ -165,4 +165,13 @@ public class JwtService {
             throw new TokenNotMatchException();
         }
     }
+
+    /**
+     * Refresh Token을 Redis에서 삭제합니다.
+     * @param refreshToken Cookie에 저장되있던 Refresh Token
+     */
+    public void deleteRefreshTokenInRedis(final String refreshToken) {
+        Optional<RefreshToken> refreshTokenFromRedis = refreshTokenRepository.findRefreshTokenByToken(refreshToken);
+        refreshTokenFromRedis.ifPresent(refreshTokenRepository::delete);
+    }
 }

--- a/src/main/java/com/backend/allreva/auth/ui/AuthController.java
+++ b/src/main/java/com/backend/allreva/auth/ui/AuthController.java
@@ -62,4 +62,16 @@ public class AuthController implements AuthControllerSwagger {
         response.addHeader("Authorization", "Bearer " + userInfoResponse.accessToken());
         return Response.onSuccess(userInfoResponse);
     }
+
+    @GetMapping("/logout")
+    public Response<Void> logout(
+            @CookieValue(name = "refreshToken", required = false) final String refreshToken,
+            final HttpServletRequest request,
+            final HttpServletResponse response
+    ) {
+        String domainName = DomainUtils.getDomainName(request);
+        authService.logout(refreshToken);
+        cookieService.deleteRefreshTokenCookie(response, domainName);
+        return Response.onSuccess();
+    }
 }

--- a/src/main/java/com/backend/allreva/auth/ui/AuthControllerSwagger.java
+++ b/src/main/java/com/backend/allreva/auth/ui/AuthControllerSwagger.java
@@ -31,4 +31,11 @@ public interface AuthControllerSwagger {
             HttpServletRequest request,
             HttpServletResponse response
     );
+
+    @Operation(summary = "로그아웃", description = "refresh token을 삭제함으로써 로그아웃합니다.")
+    Response<Void> logout(
+            final String refreshToken,
+            final HttpServletRequest request,
+            final HttpServletResponse response
+    );
 }

--- a/src/main/java/com/backend/allreva/common/util/CookieUtils.java
+++ b/src/main/java/com/backend/allreva/common/util/CookieUtils.java
@@ -28,4 +28,22 @@ public final class CookieUtils {
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
+
+    // 쿠키 제거
+    public static void deleteCookie(
+            final HttpServletResponse response,
+            final String cookieDomain,
+            final String name
+    ) {
+        ResponseCookie cookie = ResponseCookie.from(name, "")
+                .domain(cookieDomain)
+                .path("/")
+                .maxAge(0) // maxAge 0
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
 }

--- a/src/main/java/com/backend/allreva/common/util/DomainUtils.java
+++ b/src/main/java/com/backend/allreva/common/util/DomainUtils.java
@@ -11,7 +11,10 @@ public final class DomainUtils {
     public static String getDomainName(HttpServletRequest request) {
         //  ️Nginx 프록시를 고려하여 `Origin` 헤더 확인
         String domainName = request.getHeader("Origin");
-        log.info("Origin: {}", domainName);
+        if (domainName == null) {
+            domainName = request.getHeader("Referer");
+        }
+        log.info("DomainName: {}", domainName);
 
         return domainName;
     }


### PR DESCRIPTION
### 연결된 issue 🌟
- closed #224 

### 구현 내용 📢
### 로그아웃 API
로그아웃 처리해도 RefreshToken Cookie가 사라지지 않아, 프론트에서 변수 처리해도 Cookie가 남아있어 `/login/check` 로직에 의해 강제 재로그인 이슈

로그아웃 API 구현으로 해결
- Redis refreshToken 제거
- Cookie maxAge 0 설정

### domain Host name 추출 추가
기존 `Origin` 헤더에서만 추출
- `Referer` Header에서도 추출할 수 있도록 수정

### 테스트 결과 🧩
정상 동작

