### PR TITLE
[ARV-224] @AuthMember 를 SimpMessageHeaderAccessor 로 대체

### DIFF
--- a/src/main/java/com/backend/allreva/chatting/message/domain/value/Content.java
+++ b/src/main/java/com/backend/allreva/chatting/message/domain/value/Content.java
@@ -1,23 +1,14 @@
 package com.backend.allreva.chatting.message.domain.value;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Setter
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@AllArgsConstructor
 public class Content {
 
     private ContentType contentType;
     private String payload;
 
-    public Content(
-            final ContentType contentType,
-            final String payload
-    ) {
-        this.contentType = contentType;
-        this.payload = payload;
-    }
 }

--- a/src/main/java/com/backend/allreva/chatting/message/ui/MessageCommandController.java
+++ b/src/main/java/com/backend/allreva/chatting/message/ui/MessageCommandController.java
@@ -1,6 +1,7 @@
 package com.backend.allreva.chatting.message.ui;
 
 import com.backend.allreva.auth.security.AuthMember;
+import com.backend.allreva.auth.security.PrincipalDetails;
 import com.backend.allreva.chatting.chat.integration.model.value.ChatType;
 import com.backend.allreva.chatting.chat.integration.model.value.PreviewMessage;
 import com.backend.allreva.chatting.chat.integration.application.ChatParticipantService;
@@ -9,13 +10,24 @@ import com.backend.allreva.chatting.message.domain.GroupMessage;
 import com.backend.allreva.chatting.message.domain.SingleMessage;
 import com.backend.allreva.chatting.message.domain.value.Content;
 import com.backend.allreva.chatting.notification.MessageSseService;
+import com.backend.allreva.common.exception.NotFoundException;
 import com.backend.allreva.member.command.domain.Member;
+import com.backend.allreva.member.command.domain.MemberRepository;
+import com.backend.allreva.member.exception.MemberNotFoundException;
+import com.backend.allreva.member.query.application.MemberQueryService;
 import lombok.RequiredArgsConstructor;
+import org.bouncycastle.asn1.x500.style.RFC4519Style;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+
+import static org.bouncycastle.asn1.x500.style.RFC4519Style.member;
 
 @RequiredArgsConstructor
 @Controller
@@ -28,6 +40,7 @@ public class MessageCommandController {
     private final MessageSseService messageSseService;
 
     private final ChatParticipantService chatParticipantService;
+    private final MemberRepository memberRepository;
 
     private final SimpMessagingTemplate messagingTemplate;
 
@@ -35,9 +48,11 @@ public class MessageCommandController {
     @MessageMapping("/single/connection/{singleChatId}")
     public void sendSingleMessage(
             @DestinationVariable final Long singleChatId,
-            @AuthMember final Member member,
-            @Payload final Content content
+            @Payload final Content content,
+            final SimpMessageHeaderAccessor accessor
     ) {
+        Member member = getMemberFromAccessor(accessor);
+
         String destination = SUB_PERSONAL_DESTINATION + singleChatId;
         SingleMessage singleMessage = messageCommandService
                 .saveSingleMessage(singleChatId, content, member);
@@ -67,9 +82,11 @@ public class MessageCommandController {
     @MessageMapping("/group/connection/{groupChatId}")
     public void sendGroupMessage(
             @DestinationVariable final Long groupChatId,
-            @AuthMember final Member member,
-            @Payload final Content content
+            @Payload final Content content,
+            final SimpMessageHeaderAccessor accessor
     ) {
+        Member member = getMemberFromAccessor(accessor);
+
         String destination = SUB_GROUP_DESTINATION + groupChatId;
         GroupMessage groupMessage = messageCommandService
                 .saveGroupMessage(groupChatId, content, member);
@@ -96,4 +113,15 @@ public class MessageCommandController {
     }
 
 
+    private Member getMemberFromAccessor(SimpMessageHeaderAccessor accessor) {
+        Authentication authentication = (Authentication) accessor.getUser();
+        if (authentication == null) {
+            throw new MemberNotFoundException();
+        }
+        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+        if (principalDetails == null) {
+            throw new MemberNotFoundException();
+        }
+        return principalDetails.getMember();
+    }
 }


### PR DESCRIPTION
### 연결된 issue 🌟
ex) 연결된 issue를 자동으로 닫기 위해 # 다음 이슈 넘버를 입력해주세요. ex) #2 
<br>
- closed #

### 구현 내용 📢
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.


### 테스트 결과 🧩
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.


### 리뷰 포인트 📌
ex) 중점으로 봐야할만한 포인트나, 논의 하고 싶은 포인트가 있다면 적어주세요!
